### PR TITLE
Store paginated results.

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -10,11 +10,8 @@ class SearchesController < ApplicationController
 		@search = Search.new({hashtag: params["hashtag"], start_date: params["start_date"], end_date: params["end_date"]})
 		@search.save
 
-		response = HTTParty.get('https://api.instagram.com/v1/tags/snow/media/recent?access_token=1458656326.1fb234f.3ca08ac5039a40ac92cc74d6cf27aa05')
+		response = HTTParty.get('https://api.instagram.com/v1/tags/pixleememories/media/recent?access_token=1458656326.1fb234f.3ca08ac5039a40ac92cc74d6cf27aa05')
 		response_body = JSON.parse(response.body)
-
-		p "is there a next page?"
-		p has_next_page_link?(response_body)
 
 		if response_body["data"]
 
@@ -22,8 +19,14 @@ class SearchesController < ApplicationController
 				filtered_result_data = filter_data(result)
 				@result = Result.create(ig_username: filtered_result_data[:ig_username], content_type: filtered_result_data[:content_type], ig_link: filtered_result_data[:ig_link], image_url: filtered_result_data[:image_url], video_url: filtered_result_data[:video_url], description: filtered_result_data[:description], search_id: @search.id)
 				end
+
+				p "is there a next page?"
+				if has_next_page_link?(response_body)
+					p 'yeah, keep going!'
+					paginate(response_body["pagination"]["next_url"], @search.id)
+				end
 		end
-		@search.test
+		# @search.test
 		# write filters to filter out things by date and hash tag inclusion
 		# puts response_body["pagination"]
 


### PR DESCRIPTION
Created helper method based on initial logic to make a GET request to the Instagram API that makes additional requests if there is a next_url attribute for the response object returned from the initial GET request and subsequent GET requests. Noticing a large load time for certain hashtags, i.e. it takes a few minutes for '#snow' and only a few seconds for '#pixleememories.' All results are stored however, checked using 'be rails c' and checking the results length for each search object.
