### PR TITLE
Include new route to handle server side pagination.

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -15,6 +15,21 @@ class ResultsController < ApplicationController
 		render json: @search.results
 	end
 
+	def show_page
+		@search = Search.find(params[:id])
+		result_offset = params[:result_offset].to_i
+		results_subset = @search.results[result_offset..(result_offset + 19)]
+		next_page_boolean = false;
+		if @search.results.length > result_offset + 10
+			next_page_boolean = true;
+		end
+		
+		# results.map!{ |result| result.to_json}
+		# next_media_set = results[page_num]
+		# render json: {search_id: @search.id, page: page_num, next_results: next_media_set}
+		render json: {search_id: @search.id, results: results_subset, next_page: next_page_boolean}
+	end
+
 	private
 		def result_params
 			params.require(:result).permit(:ig_username, :tag_time, :type, :ig_link, :image_url, :video_url, :description)

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -21,7 +21,9 @@ class SearchesController < ApplicationController
 				end
 
 				p "is there a next page?"
+				next_page_boolean = false
 				if has_next_page_link?(response_body)
+					next_page_boolean = true
 					p 'yeah, keep going!'
 					InstagrabsWorker.perform_async(response_body["pagination"]["next_url"], @search.id)
 					# paginate(response_body["pagination"]["next_url"], @search.id)
@@ -39,9 +41,10 @@ class SearchesController < ApplicationController
 		# click the load button and hit a second route in the controller that will make a request that renders the images/videos without storing them because the background job is already going
 		# next route for 20 doesnt need to know instagram api, it hits your database
 		# could have a function click first - my . separate functions. hit initial route to call the function thatd does the paging n pass in records
-		# function for calling and function for posting
+		# function for calling and function for postinggdat
 		# 1st call process return to function that calls get more and return
-		render json: @search.results
+
+		render json: {search_id: @search.id, results: @search.results, next_page: next_page_boolean}
 	end
 
 
@@ -54,6 +57,7 @@ class SearchesController < ApplicationController
 		@search = Search.find(params[:id])
 		render json: @search
 	end
+
 
 	private
 		def search_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
     end
     get 'welcome/index'
     root 'welcome#index'
+
+    # serves "paginated" results
+    get '/searches/:id/results/page/:result_offset' => 'results#show_page'
   end
 
 end


### PR DESCRIPTION
Implemented a new route that would take a page offset param and a search object id param. Given the params, the API will query the database for the corresponding search object, and retrieve a subset from that object's results. The subset begins with the offset and includes 19 additional results. Because of the undefined method error bug, the API tends to pause when it is unable successfully make a GET request to the Instagram API, causing the client side to think that there are no more images available for rendering. Will fix given time.
